### PR TITLE
Attach form to document body prior to submission.

### DIFF
--- a/bulk_admin/static/bulk_admin/js/bulk.js
+++ b/bulk_admin/static/bulk_admin/js/bulk.js
@@ -71,6 +71,10 @@
                 }
 
                 $totalFormCountInput.attr('value', this.files.length);
+
+                // HTML spec updates require forms to be attached to document 
+                // body before submission.
+                $(document.body).append($form);
                 $form.submit();
 
                 submitted = true;


### PR DESCRIPTION
Fixes issue #1 introduced in chrome 56.